### PR TITLE
Add side load repository for managing audio assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ Run the analyzer from the command line:
 python app.py --file path/to/song.wav --microphone --log bpm_log.txt
 ```
 
+### Side load repository
+
+To reuse audio assets across multiple analysis runs you can set up a side load
+repository. The repository manages imported files, assigns them stable
+identifiers and keeps optional metadata describing the origin of each file.
+
+```bash
+python app.py \
+    --file path/to/song.wav \
+    --side-load-repo ./sideloads \
+    --side-load-metadata project=SunoAI,genre=electronic
+```
+
+- If ``path/to/song.wav`` exists it will be copied into the repository and a
+  manifest entry is created. Subsequent executions can reference either the
+  original path or the generated identifier shown inside ``sideloads/manifest.json``.
+- When ``--file`` refers to an identifier the stored copy inside the repository
+  will be used automatically.
+- Metadata values are optional, but they can help to keep track of the context
+  in which each file was added.
+
 Key options:
 
 - `--file`: optional path to a wave file that should be analysed.

--- a/app.py
+++ b/app.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from statistics import mean, median
 from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
 
+from repository import SideLoadRepository, parse_metadata_pairs
+
 
 @dataclass
 class AnalysisConfig:
@@ -580,6 +582,19 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         default=AnalysisConfig.chunk_size,
         help="Frame size for streaming audio",
     )
+    parser.add_argument(
+        "--side-load-repo",
+        dest="side_load_repo",
+        help="Workspace directory used to manage side loaded files",
+    )
+    parser.add_argument(
+        "--side-load-metadata",
+        dest="side_load_metadata",
+        help=(
+            "Comma separated list of key=value pairs stored with imported files "
+            "inside the side load repository"
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -587,8 +602,25 @@ def create_sources(args: argparse.Namespace) -> List[AudioSource]:
     sources: List[AudioSource] = []
     sample_rate = args.sample_rate
     chunk_size = args.chunk_size
+    repository: Optional[SideLoadRepository] = None
+    metadata: Optional[dict] = None
+    if args.side_load_repo:
+        repository = SideLoadRepository(args.side_load_repo)
+        if args.side_load_metadata:
+            try:
+                metadata = parse_metadata_pairs(
+                    part.strip() for part in args.side_load_metadata.split(",")
+                )
+            except ValueError as exc:
+                raise SystemExit(str(exc)) from exc
     if args.file_path:
-        sources.append(FileAudioSource(args.file_path, sample_rate, chunk_size))
+        file_path = args.file_path
+        if repository is not None:
+            try:
+                file_path = repository.resolve(file_path, metadata=metadata)
+            except FileNotFoundError as exc:
+                raise SystemExit(str(exc)) from exc
+        sources.append(FileAudioSource(file_path, sample_rate, chunk_size))
     if args.use_microphone:
         sources.append(MicrophoneAudioSource(sample_rate, chunk_size))
     if not sources:

--- a/repository.py
+++ b/repository.py
@@ -1,0 +1,175 @@
+"""Side load repository for managing extended audio data."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+from uuid import uuid4
+
+
+@dataclass
+class SideLoadEntry:
+    """Representation of a stored file inside the side load repository."""
+
+    identifier: str
+    original_name: str
+    stored_name: str
+    size_bytes: int
+    created_at: str
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the entry so it can be persisted in ``manifest.json``."""
+
+        return {
+            "original_name": self.original_name,
+            "stored_name": self.stored_name,
+            "size_bytes": self.size_bytes,
+            "created_at": self.created_at,
+            "metadata": self.metadata,
+        }
+
+
+class SideLoadRepository:
+    """Manage a workspace for side loaded files.
+
+    The repository keeps a manifest that maps generated identifiers to the
+    files stored in the ``files`` sub directory. Files can be resolved either by
+    their identifier or by providing a file path that will be imported into the
+    repository on demand.
+    """
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root)
+        self.files_dir = self.root / "files"
+        self.manifest_path = self.root / "manifest.json"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.files_dir.mkdir(parents=True, exist_ok=True)
+        self._entries = self._load_manifest()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def store_file(
+        self, source_path: Path | str, metadata: Optional[Dict[str, str]] = None
+    ) -> SideLoadEntry:
+        """Copy ``source_path`` into the repository and return the entry.
+
+        ``source_path`` must exist on disk. The file is copied into the
+        repository with a generated identifier and the manifest is updated.
+        """
+
+        source = Path(source_path)
+        if not source.is_file():
+            raise FileNotFoundError(f"Source file not found: {source}")
+        metadata = {key: str(value) for key, value in (metadata or {}).items()}
+        identifier = self._generate_identifier(source.name)
+        stored_name = f"{identifier}{source.suffix}"
+        destination = self.files_dir / stored_name
+        shutil.copy2(source, destination)
+        created_at = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        entry = SideLoadEntry(
+            identifier=identifier,
+            original_name=source.name,
+            stored_name=stored_name,
+            size_bytes=destination.stat().st_size,
+            created_at=created_at,
+            metadata=metadata,
+        )
+        self._entries[identifier] = entry
+        self._save_manifest()
+        return entry
+
+    def resolve(
+        self, reference: str, metadata: Optional[Dict[str, str]] = None
+    ) -> str:
+        """Return a file path inside the repository for ``reference``.
+
+        When ``reference`` refers to an existing file on disk the file is copied
+        into the repository and the stored location is returned. Otherwise the
+        reference is interpreted as an identifier that must already exist in the
+        manifest.
+        """
+
+        candidate = Path(reference)
+        if candidate.is_file():
+            entry = self.store_file(candidate, metadata=metadata)
+            return str(self.files_dir / entry.stored_name)
+        entry = self.get_entry(reference)
+        if entry is None:
+            raise FileNotFoundError(
+                f"Unable to resolve '{reference}'. Provide an existing file path "
+                "or a known side load identifier."
+            )
+        return str(self.files_dir / entry.stored_name)
+
+    def get_entry(self, identifier: str) -> Optional[SideLoadEntry]:
+        return self._entries.get(identifier)
+
+    def list_entries(self) -> List[SideLoadEntry]:
+        return list(self._entries.values())
+
+    def remove(self, identifier: str) -> None:
+        entry = self._entries.pop(identifier, None)
+        if entry is None:
+            raise KeyError(identifier)
+        stored_file = self.files_dir / entry.stored_name
+        if stored_file.exists():
+            stored_file.unlink()
+        self._save_manifest()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _load_manifest(self) -> Dict[str, SideLoadEntry]:
+        if not self.manifest_path.exists():
+            return {}
+        data = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        entries: Dict[str, SideLoadEntry] = {}
+        for identifier, payload in data.items():
+            entries[identifier] = SideLoadEntry(
+                identifier=identifier,
+                original_name=payload["original_name"],
+                stored_name=payload["stored_name"],
+                size_bytes=int(payload["size_bytes"]),
+                created_at=payload["created_at"],
+                metadata={
+                    str(key): str(value) for key, value in payload.get("metadata", {}).items()
+                },
+            )
+        return entries
+
+    def _save_manifest(self) -> None:
+        data = {identifier: entry.to_dict() for identifier, entry in self._entries.items()}
+        self.manifest_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def _generate_identifier(self, name: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+        base = slug or "entry"
+        identifier = f"{base}-{uuid4().hex[:8]}"
+        while identifier in self._entries:
+            identifier = f"{base}-{uuid4().hex[:8]}"
+        return identifier
+
+
+def parse_metadata_pairs(pairs: Iterable[str]) -> Dict[str, str]:
+    """Convert an iterable of ``key=value`` strings into a metadata dictionary."""
+
+    metadata: Dict[str, str] = {}
+    for pair in pairs:
+        if not pair:
+            continue
+        if "=" not in pair:
+            raise ValueError(f"Invalid metadata entry '{pair}'. Use key=value format.")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("Metadata keys must not be empty.")
+        metadata[key] = value.strip()
+    return metadata
+

--- a/test_app.py
+++ b/test_app.py
@@ -15,6 +15,7 @@ from app import (
     MicrophoneAudioSource,
     generate_click_track,
 )
+from repository import SideLoadRepository
 
 
 def write_wave(path: Path, audio: Sequence[float], sample_rate: int) -> None:
@@ -108,3 +109,24 @@ def test_microphone_variations_are_logged(tmp_path: Path) -> None:
     last_variation = variations[-1].split("\t")
     observed_bpm = float(last_variation[2])
     assert observed_bpm > 110.0
+
+
+def test_side_load_repository_imports_and_persists(tmp_path: Path) -> None:
+    repo_path = tmp_path / "workspace"
+    repo = SideLoadRepository(repo_path)
+    source_file = tmp_path / "sample.wav"
+    source_file.write_bytes(b"wave-data")
+    entry = repo.store_file(source_file, metadata={"project": "suno"})
+    assert (repo.files_dir / entry.stored_name).is_file()
+
+    resolved_path = repo.resolve(entry.identifier)
+    assert Path(resolved_path).read_bytes() == b"wave-data"
+
+    second_file = tmp_path / "second.wav"
+    second_file.write_bytes(b"another")
+    resolved_second = repo.resolve(str(second_file))
+    assert Path(resolved_second).read_bytes() == b"another"
+
+    repo_reloaded = SideLoadRepository(repo_path)
+    identifiers = {item.identifier for item in repo_reloaded.list_entries()}
+    assert entry.identifier in identifiers


### PR DESCRIPTION
## Summary
- add a repository module with a side load workspace for storing imported audio files and metadata
- integrate the CLI with optional repository arguments so file sources can be resolved or imported automatically
- document the workflow and add unit coverage for repository persistence

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68e012ca95f4832e9f12bfeafdc5a8ba)