### PR TITLE
Support audio directory inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python app.py --file path/to/song.wav --microphone --log bpm_log.txt
 
 Key options:
 
-- `--file`: optional path to a wave file that should be analysed.
+- `--file`: optional path to a wave file, or a directory of `.wav`/`.wave` files, that should be analysed.
 - `--microphone`: enables microphone capture (requires the `sounddevice`
   package and audio hardware).
 - `--log`: location of the tempo log (defaults to `bpm_log.txt`).

--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ class FileAudioSource(AudioSource):
         if self._position >= len(self._data):
             return None
         end = min(self._position + self.chunk_size, len(self._data))
-        chunk = self._data[self._position:end]
+        chunk = self._data[self._position : end]
         self._position = end
         if len(chunk) < self.chunk_size:
             chunk = chunk + [0.0] * (self.chunk_size - len(chunk))
@@ -165,7 +165,9 @@ class BpmLogWriter:
 
     def log_measurement(self, timestamp: float, bpm: float, reference: float) -> None:
         delta = bpm - reference
-        label = "VARIATION" if abs(delta) >= self._variation_threshold else "MEASUREMENT"
+        label = (
+            "VARIATION" if abs(delta) >= self._variation_threshold else "MEASUREMENT"
+        )
         self._file.write(
             f"{label}\t{timestamp:.2f}\t{bpm:.2f}\t{reference:.2f}\t{delta:+.2f}\n"
         )
@@ -208,7 +210,10 @@ class TempoRegressor:
 
     def _train_model(self) -> List[float]:
         samples = 40
-        bpms = [self.min_bpm + i * (self.max_bpm - self.min_bpm) / (samples - 1) for i in range(samples)]
+        bpms = [
+            self.min_bpm + i * (self.max_bpm - self.min_bpm) / (samples - 1)
+            for i in range(samples)
+        ]
         feature_rows: List[List[float]] = []
         targets: List[float] = []
         for bpm in bpms:
@@ -250,7 +255,9 @@ class TempoRegressor:
         normalize(envelope)
         return envelope
 
-    def _extract_features(self, envelope: List[float]) -> Optional[Tuple[float, List[float]]]:
+    def _extract_features(
+        self, envelope: List[float]
+    ) -> Optional[Tuple[float, List[float]]]:
         if not envelope:
             return None
         frame_rate = self.sample_rate / self.hop_size
@@ -268,13 +275,13 @@ class TempoRegressor:
             intervals = [peaks[i + 1] - peaks[i] for i in range(len(peaks) - 1)]
             lag_frames = max(1, int(round(median(intervals))))
         best_value = autocorr[min(lag_frames, len(autocorr) - 1)]
-        secondary_index, secondary_value = secondary_peak(autocorr, best_index, min_lag, max_lag)
+        secondary_index, secondary_value = secondary_peak(
+            autocorr, best_index, min_lag, max_lag
+        )
         lag_seconds = lag_frames / frame_rate
         secondary_seconds = secondary_index / frame_rate
         base_bpm = 60.0 / lag_seconds if lag_seconds > 0 else 0.0
-        secondary_ratio = (
-            (secondary_value / best_value) if best_value > 0 else 0.0
-        )
+        secondary_ratio = (secondary_value / best_value) if best_value > 0 else 0.0
         features = [
             best_value,
             secondary_value,
@@ -317,7 +324,8 @@ class AudioAnalyzer:
                 self._maybe_log_measurement()
                 if (
                     max_duration is not None
-                    and self._processed_samples / self.config.sample_rate >= max_duration
+                    and self._processed_samples / self.config.sample_rate
+                    >= max_duration
                 ):
                     break
         finally:
@@ -508,7 +516,9 @@ def detect_peaks(envelope: List[float]) -> List[int]:
     return peaks
 
 
-def resample_audio(audio: List[float], original_rate: int, target_rate: int) -> List[float]:
+def resample_audio(
+    audio: List[float], original_rate: int, target_rate: int
+) -> List[float]:
     if original_rate == target_rate or not audio:
         return list(audio)
     duration = len(audio) / float(original_rate)
@@ -583,16 +593,51 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+SUPPORTED_AUDIO_EXTENSIONS = {".wav", ".wave"}
+
+
+def discover_audio_files(path: str) -> List[str]:
+    """Return supported audio files for a file or directory path.
+
+    Directory inputs are scanned recursively and returned in sorted order so CLI
+    runs are deterministic across platforms.
+    """
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    if os.path.isfile(path):
+        extension = os.path.splitext(path)[1].lower()
+        if extension not in SUPPORTED_AUDIO_EXTENSIONS:
+            raise ValueError(
+                f"Unsupported audio file extension: {extension or '<none>'}"
+            )
+        return [path]
+
+    matches: List[str] = []
+    for root, dirnames, filenames in os.walk(path):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            extension = os.path.splitext(filename)[1].lower()
+            if extension in SUPPORTED_AUDIO_EXTENSIONS:
+                matches.append(os.path.join(root, filename))
+    if not matches:
+        raise ValueError(f"No supported audio files found in directory: {path}")
+    return matches
+
+
 def create_sources(args: argparse.Namespace) -> List[AudioSource]:
     sources: List[AudioSource] = []
     sample_rate = args.sample_rate
     chunk_size = args.chunk_size
     if args.file_path:
-        sources.append(FileAudioSource(args.file_path, sample_rate, chunk_size))
+        for file_path in discover_audio_files(args.file_path):
+            sources.append(FileAudioSource(file_path, sample_rate, chunk_size))
     if args.use_microphone:
         sources.append(MicrophoneAudioSource(sample_rate, chunk_size))
     if not sources:
-        raise SystemExit("No audio sources selected. Specify --file and/or --microphone.")
+        raise SystemExit(
+            "No audio sources selected. Specify --file and/or --microphone."
+        )
     return sources
 
 

--- a/test_app.py
+++ b/test_app.py
@@ -13,6 +13,7 @@ from app import (
     AudioAnalyzer,
     FileAudioSource,
     MicrophoneAudioSource,
+    create_sources,
     generate_click_track,
 )
 
@@ -80,6 +81,42 @@ def test_file_source_detects_expected_bpm(tmp_path: Path) -> None:
     baseline_line = next(line for line in lines if line.startswith("BASELINE"))
     baseline_bpm = float(baseline_line.split("\t")[2])
     assert baseline_bpm == pytest.approx(target_bpm, abs=2.0)
+
+
+def test_create_sources_accepts_directory_of_wave_files(tmp_path: Path) -> None:
+    sample_rate = 44_100
+    chunk_size = 4_096
+    audio_dir = tmp_path / "audio"
+    nested_dir = audio_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    write_wave(
+        audio_dir / "first.wav",
+        generate_click_track(90.0, 1.0, sample_rate),
+        sample_rate,
+    )
+    write_wave(
+        nested_dir / "second.wave",
+        generate_click_track(110.0, 1.0, sample_rate),
+        sample_rate,
+    )
+    (audio_dir / "notes.txt").write_text("ignore me", encoding="utf-8")
+
+    args = type(
+        "Args",
+        (),
+        {
+            "file_path": str(audio_dir),
+            "sample_rate": sample_rate,
+            "chunk_size": chunk_size,
+            "use_microphone": False,
+        },
+    )()
+
+    sources = create_sources(args)
+
+    assert len(sources) == 2
+    for source in sources:
+        source.close()
 
 
 def test_microphone_variations_are_logged(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Allow users to pass a directory to the `--file` CLI flag so multiple wave tracks can be analysed in batch.
- Make CLI behavior deterministic by scanning directories recursively in sorted order and only accepting supported audio types.

### Description
- Added `SUPPORTED_AUDIO_EXTENSIONS` and a `discover_audio_files(path: str) -> List[str]` helper that validates paths and recursively collects `.wav`/`.wave` files in deterministic order.
- Updated `create_sources` to call `discover_audio_files` and instantiate a `FileAudioSource` for each discovered file while preserving `MicrophoneAudioSource` support.
- Updated `README.md` to document directory inputs for `--file` and added `test_create_sources_accepts_directory_of_wave_files` to `test_app.py` to cover nested files and ignored non-audio files.
- Ran automatic code formatting which adjusted a few line breaks for consistency.

### Testing
- Ran code formatting with `python -m black app.py test_app.py` which completed successfully. 
- Ran the test suite with `pytest -q` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5da1b1eea8832eb8d01b80b7e2acb3)