### PR TITLE
Add starter Forza Horizon 6 Flexbar companion plugin (backend, UI, resources, manifest, README)

### DIFF
--- a/flexbar-forza-horizon-6-plugin/README.md
+++ b/flexbar-forza-horizon-6-plugin/README.md
@@ -1,0 +1,31 @@
+# Forza Horizon 6 Flexbar Companion
+
+Starter Flexbar plugin concept for Forza Horizon 6. The first version focuses on
+useful shortcut pages and leaves clean integration points for telemetry once the
+final game data-output behavior is known.
+
+## Planned pages
+
+- **Cruise**: map, rewind, camera, radio, photo mode, and telemetry toggle.
+- **Race**: rewind, look back, camera, pause, clip capture, and telemetry HUD.
+- **Drift / Touge**: handbrake, telemetry, reset car, photo, clip capture, and tuning shortcut.
+- **Photo / Creator**: photo mode, screenshot, hide UI, OBS, captures folder, and back button.
+- **Telemetry HUD**: speed, gear, RPM, skill multiplier, and connection state.
+
+## Development notes
+
+The backend currently runs as a static shortcut companion and exposes a small
+`updateTelemetry` pathway for future live data. When Forza Horizon 6 telemetry
+is confirmed, wire the telemetry listener into `backend/index.js` and forward
+normalized speed/RPM/gear data to the dynamic key renderer.
+
+## Suggested local workflow
+
+```bash
+npm install -g @eniactech/flexcli
+flexcli link ./flexbar-forza-horizon-6-plugin
+flexcli restart
+```
+
+If your FlexCLI package is published under a different npm scope, use the scope
+that matches your installed FlexDesigner SDK version.

--- a/flexbar-forza-horizon-6-plugin/backend/index.js
+++ b/flexbar-forza-horizon-6-plugin/backend/index.js
@@ -1,0 +1,148 @@
+"use strict";
+
+/**
+ * Starter backend for a Flexbar Forza Horizon 6 companion plugin.
+ *
+ * The implementation is intentionally defensive: it works as a static shortcut
+ * companion today and keeps telemetry/game-state integration behind small
+ * adapter functions that can be wired to the final Forza Horizon 6 telemetry
+ * interface when it is available.
+ */
+
+const { plugin, logger } = require("@eniactech/flexdesigner-sdk");
+
+const DEFAULT_PROFILE = {
+  activeMode: "cruise",
+  telemetry: {
+    connected: false,
+    speedMph: 0,
+    rpm: 0,
+    gear: "N",
+    skillMultiplier: "1.0x",
+  },
+};
+
+const MODES = {
+  cruise: {
+    title: "Cruise",
+    accent: "#35d0ff",
+    actions: ["Map", "Rewind", "Camera", "Radio", "Photo", "Telemetry"],
+  },
+  race: {
+    title: "Race",
+    accent: "#ff3b30",
+    actions: ["Rewind", "Look Back", "Camera", "Pause", "Clip", "Telemetry"],
+  },
+  drift: {
+    title: "Drift",
+    accent: "#b56cff",
+    actions: ["Handbrake", "Telemetry", "Reset", "Photo", "Clip", "Tune"],
+  },
+  photo: {
+    title: "Photo",
+    accent: "#ffd60a",
+    actions: ["Photo Mode", "Screenshot", "Hide UI", "OBS", "Captures", "Back"],
+  },
+};
+
+const state = structuredCloneSafe(DEFAULT_PROFILE);
+
+plugin.on?.("plugin.alive", () => {
+  logger.info?.("Forza Horizon 6 Companion started");
+  renderActiveMode();
+});
+
+plugin.on?.("plugin.dead", () => {
+  logger.info?.("Forza Horizon 6 Companion stopped");
+});
+
+plugin.on?.("plugin.data", (payload) => {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+
+  if (payload.action === "setMode" && MODES[payload.mode]) {
+    state.activeMode = payload.mode;
+    renderActiveMode();
+    return;
+  }
+
+  if (payload.action === "telemetry") {
+    updateTelemetry(payload.telemetry || {});
+  }
+});
+
+function renderActiveMode() {
+  const mode = MODES[state.activeMode] || MODES.cruise;
+  logger.info?.(`Rendering ${mode.title} mode with actions: ${mode.actions.join(", ")}`);
+
+  if (!plugin.dynamickey?.clear || !plugin.dynamickey?.add) {
+    return;
+  }
+
+  plugin.dynamickey.clear();
+  plugin.dynamickey.add({
+    id: "fh6.mode.header",
+    title: `${mode.title} Mode`,
+    subtitle: state.telemetry.connected ? "Telemetry online" : "Shortcut page",
+    color: mode.accent,
+  });
+
+  for (const action of mode.actions) {
+    plugin.dynamickey.add({
+      id: `fh6.action.${slug(action)}`,
+      title: action,
+      color: mode.accent,
+    });
+  }
+
+  renderTelemetryHud();
+}
+
+function updateTelemetry(nextTelemetry) {
+  state.telemetry = {
+    ...state.telemetry,
+    ...nextTelemetry,
+    connected: true,
+  };
+  renderTelemetryHud();
+}
+
+function renderTelemetryHud() {
+  if (!plugin.dynamickey?.add && !plugin.dynamickey?.update) {
+    return;
+  }
+
+  const telemetry = state.telemetry;
+  const payload = {
+    id: "fh6.telemetry.hud",
+    title: `${Math.round(telemetry.speedMph)} mph`,
+    subtitle: `Gear ${telemetry.gear} · ${Math.round(telemetry.rpm)} rpm · ${telemetry.skillMultiplier}`,
+    color: telemetry.connected ? "#32d74b" : "#8e8e93",
+  };
+
+  if (plugin.dynamickey?.update) {
+    plugin.dynamickey.update(payload);
+  } else {
+    plugin.dynamickey.add(payload);
+  }
+}
+
+function slug(value) {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function structuredCloneSafe(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+
+module.exports = {
+  MODES,
+  DEFAULT_PROFILE,
+  slug,
+};

--- a/flexbar-forza-horizon-6-plugin/manifest.json
+++ b/flexbar-forza-horizon-6-plugin/manifest.json
@@ -1,0 +1,47 @@
+{
+  "id": "com.example.flexbar.forza-horizon-6",
+  "name": "Forza Horizon 6 Companion",
+  "version": "0.1.0",
+  "author": "Codex",
+  "description": "Starter Flexbar companion for Forza Horizon 6 with driving, racing, drifting, photo, and telemetry pages.",
+  "repository": "https://example.com/flexbar-forza-horizon-6-plugin",
+  "backend": "backend/index.js",
+  "configPage": "ui/config.html",
+  "keyLibrary": [
+    {
+      "id": "mode.cruise",
+      "name": "Cruise Mode",
+      "category": "Forza Horizon 6",
+      "type": "default",
+      "icon": "resources/cruise.svg"
+    },
+    {
+      "id": "mode.race",
+      "name": "Race Mode",
+      "category": "Forza Horizon 6",
+      "type": "default",
+      "icon": "resources/race.svg"
+    },
+    {
+      "id": "mode.drift",
+      "name": "Drift Mode",
+      "category": "Forza Horizon 6",
+      "type": "default",
+      "icon": "resources/drift.svg"
+    },
+    {
+      "id": "mode.photo",
+      "name": "Photo Mode",
+      "category": "Forza Horizon 6",
+      "type": "default",
+      "icon": "resources/photo.svg"
+    },
+    {
+      "id": "telemetry.hud",
+      "name": "Telemetry HUD",
+      "category": "Forza Horizon 6",
+      "type": "dynamic",
+      "icon": "resources/telemetry.svg"
+    }
+  ]
+}

--- a/flexbar-forza-horizon-6-plugin/resources/cruise.svg
+++ b/flexbar-forza-horizon-6-plugin/resources/cruise.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="cruise">
+  <rect width="128" height="128" rx="28" fill="#111827"/>
+  <circle cx="64" cy="64" r="38" fill="#2563eb" opacity="0.28"/>
+  <text x="64" y="72" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff">cruise</text>
+</svg>

--- a/flexbar-forza-horizon-6-plugin/resources/drift.svg
+++ b/flexbar-forza-horizon-6-plugin/resources/drift.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="drift">
+  <rect width="128" height="128" rx="28" fill="#111827"/>
+  <circle cx="64" cy="64" r="38" fill="#2563eb" opacity="0.28"/>
+  <text x="64" y="72" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff">drift</text>
+</svg>

--- a/flexbar-forza-horizon-6-plugin/resources/photo.svg
+++ b/flexbar-forza-horizon-6-plugin/resources/photo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="photo">
+  <rect width="128" height="128" rx="28" fill="#111827"/>
+  <circle cx="64" cy="64" r="38" fill="#2563eb" opacity="0.28"/>
+  <text x="64" y="72" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff">photo</text>
+</svg>

--- a/flexbar-forza-horizon-6-plugin/resources/race.svg
+++ b/flexbar-forza-horizon-6-plugin/resources/race.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="race">
+  <rect width="128" height="128" rx="28" fill="#111827"/>
+  <circle cx="64" cy="64" r="38" fill="#2563eb" opacity="0.28"/>
+  <text x="64" y="72" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff">race</text>
+</svg>

--- a/flexbar-forza-horizon-6-plugin/resources/telemetry.svg
+++ b/flexbar-forza-horizon-6-plugin/resources/telemetry.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-label="telemetry">
+  <rect width="128" height="128" rx="28" fill="#111827"/>
+  <circle cx="64" cy="64" r="38" fill="#2563eb" opacity="0.28"/>
+  <text x="64" y="72" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="700" fill="#ffffff">telemetry</text>
+</svg>

--- a/flexbar-forza-horizon-6-plugin/ui/config.html
+++ b/flexbar-forza-horizon-6-plugin/ui/config.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Forza Horizon 6 Companion Settings</title>
+    <style>
+      body {
+        background: #101014;
+        color: #f5f5f7;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 24px;
+      }
+
+      .card {
+        background: #1c1c22;
+        border: 1px solid #31313a;
+        border-radius: 16px;
+        max-width: 720px;
+        padding: 24px;
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      label {
+        display: block;
+        font-weight: 700;
+        margin-top: 20px;
+      }
+
+      select,
+      input {
+        background: #2a2a32;
+        border: 1px solid #4b4b56;
+        border-radius: 10px;
+        color: #ffffff;
+        font: inherit;
+        margin-top: 8px;
+        padding: 10px 12px;
+        width: 100%;
+      }
+
+      p {
+        color: #c7c7d1;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Forza Horizon 6 Companion</h1>
+      <p>
+        Pick a startup page for driving, racing, drifting, or photo sessions.
+        Telemetry settings are placeholders until the final Forza Horizon 6 data
+        output behavior is confirmed.
+      </p>
+
+      <label for="startup-mode">Startup page</label>
+      <select id="startup-mode" name="startup-mode">
+        <option value="cruise">Cruise shortcuts</option>
+        <option value="race">Race controls</option>
+        <option value="drift">Drift / touge controls</option>
+        <option value="photo">Photo and creator tools</option>
+      </select>
+
+      <label for="telemetry-port">Telemetry UDP port</label>
+      <input id="telemetry-port" name="telemetry-port" type="number" min="1" max="65535" value="5300">
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a starter Flexbar companion for Forza Horizon 6 with shortcut pages and a telemetry-ready backend surface.
- Ship a minimal, defensive backend and UI so the plugin can be linked and iterated while final FH6 telemetry output is still unknown.

### Description

- Add a new plugin at `flexbar-forza-horizon-6-plugin` with `manifest.json`, `README.md`, and example `ui/config.html` for settings and startup page selection.
- Implement a defensive backend at `backend/index.js` that exposes `DEFAULT_PROFILE`, `MODES`, `updateTelemetry`, `renderActiveMode`, `renderTelemetryHud`, `slug`, and `structuredCloneSafe` and integrates with `@eniactech/flexdesigner-sdk` dynamic keys.
- Include simple SVG icon resources (`resources/*.svg`) for the modes and a telemetry HUD key entry in the manifest `keyLibrary`.
- Provide developer workflow notes and `flexcli` linking instructions in the `README.md` and keep telemetry wiring points clearly documented for future live-data integration.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6270f21344832e835b046b1e2e61da)